### PR TITLE
Turn on declaration option for package

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -30,7 +30,7 @@ class KeyvFile<K, V> {
   _lastExpire: number
   _saveTimer?: NodeJS.Timer
 
-  constructor(opts?: typeof defaultOpts) {
+  constructor(opts?: Partial<typeof defaultOpts>) {
     this._opts = {
       ...this._opts,
       ...opts,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */


### PR DESCRIPTION
I use TS in my project, and TS cannot find typings because `lib/index.d.ts` doesn't exist.

![screenshot from 2018-12-26 13-55-47](https://user-images.githubusercontent.com/1208639/50443823-0c315180-0916-11e9-8a70-32e4014653af.png)

Also I fixed typings for constructor options cause all options are optional.

![screenshot from 2018-12-26 14-03-10](https://user-images.githubusercontent.com/1208639/50444043-2f103580-0917-11e9-8a17-a2c260f18aa2.png)